### PR TITLE
Add Akron Beacon Journal

### DIFF
--- a/services/web__ohio_com.py
+++ b/services/web__ohio_com.py
@@ -1,0 +1,8 @@
+refresh = 6
+version = 20151222
+
+urls = ['http://www.ohio.com/cmlink/1.114425',
+        'http://www.ohio.com/news/break-news']
+regex = [r'^https?:\/\/[^\/]*ohio\.com\/news\/']	
+videoregex = []
+liveregex = []


### PR DESCRIPTION
Add ABJ, much like #11, but with more URLs and less frequent scrapes.