### PR TITLE
Grab source url as well for improved replay

### DIFF
--- a/main.py
+++ b/main.py
@@ -480,6 +480,9 @@ def checkurl(service, urlnum, url, regexes, videoregexes, liveregexes):
 						if not extractedurl in grablistnormal:
 							grablistnormal.append(extractedurl)
 					count += 1
+					if count == 1:
+						if not url in grablistnormal:
+							grablistnormal.append(url)
 			if os.path.isfile('list-videos-immediate' + imgrabfiles[0]):
 				with open('rsync_targets', 'r') as file:
 					rsync_targets = [target for target in file.read().splitlines() if target != '']


### PR DESCRIPTION
Would be nice to grab the source url as well once every interval if we find a new url on the grab of this source url. This will improve replay of the website since all found articles can be found on at least one snapshot of the source url.