### PR TITLE
Added missing services from the Alexa Top 40 News Sites

### DIFF
--- a/services/web__breitbart_com.py
+++ b/services/web__breitbart_com.py
@@ -1,0 +1,16 @@
+refresh = 6
+version = 20160403.01
+
+urls = ['http://www.breitbart.com/',
+	'http://www.breitbart.com/big-government/',
+	'http://www.breitbart.com/big-journalism/',
+	'http://www.breitbart.com/big-hollywood/',
+	'http://www.breitbart.com/national-security/',
+	'http://www.breitbart.com/tech/',
+	'http://www.breitbart.com/video/',
+	'http://www.breitbart.com/sports/',
+	'http://www.breitbart.com/news/',
+	'http://feeds.feedburner.com/breitbart']
+regex = [r'^https?:\/\/[^\/]*breitbart\.com']
+videoregex = ['\/video\/']
+liveregex = []

--- a/services/web__chron_com.py
+++ b/services/web__chron_com.py
@@ -1,0 +1,33 @@
+refresh = 5
+version = 20160403.01
+
+urls = ['http://www.chron.com/',
+	'http://www.chron.com/news/houston-texas/',
+	'http://www.chron.com/news/nation-world/',
+	'http://www.chron.com/sports/',
+	'http://www.chron.com/business/',
+	'http://www.chron.com/entertainment/',
+	'http://www.chron.com/life/',
+	'http://www.chron.com/rss/feed/News-270.php',
+	'http://www.chron.com/rss/feed/Houston-and-Texas-272.php',
+	'http://www.chron.com/rss/feed/Weather-273.php',
+	'http://www.chron.com/rss/feed/Traffic-274.php',
+	'http://www.chron.com/rss/feed/Politics-275.php',
+	'http://www.chron.com/rss/feed/Business-287.php',
+	'http://www.chron.com/rss/feed/Energy-288.php',
+	'http://www.chron.com/rss/feed/Real-Estate-290.php',
+	'http://www.chron.com/rss/feed/Technology-289.php',
+	'http://www.chron.com/rss/feed/Economy-292.php',
+	'http://www.chron.com/sports/feed/Houston-Astros-News-from-the-Houston-Chronicle-608.php',
+	'http://www.chron.com/sports/feed/Houston-Rockets-News-from-the-Houston-Chronicle-427.php',
+	'http://www.chron.com/sports/texans/feed/Houston-Texans-News-from-the-Houston-Chronicle-377.php',
+	'http://www.chron.com/sports/feed/Houston-College-H-S-Sports-News-from-the-1290.php',
+	'http://www.chron.com/rss/feed/Entertainment-293.php',
+	'http://www.chron.com/rss/feed/Movies-296.php',
+	'http://www.chron.com/rss/feed/Music-295.php',
+	'http://www.chron.com/rss/feed/Life-297.php',
+	'http://www.chron.com/rss/feed/Food-299.php',
+	'http://www.chron.com/rss/feed/Pets-302.php']
+regex = [r'^https?:\/\/[^\/]*chron\.com']
+videoregex = []
+liveregex = []

--- a/services/web__cnbc_com.py
+++ b/services/web__cnbc_com.py
@@ -1,0 +1,20 @@
+refresh = 5
+version = 20160403.01
+
+urls = ['http://www.cnbc.com/',
+	'http://www.cnbc.com/world/',
+	'http://www.cnbc.com/us-news/',
+	'http://www.cnbc.com/markets/',
+	'http://www.cnbc.com/investing/',
+	'http://www.cnbc.com/technology/',
+	'http://www.cnbc.com/make-it/',
+	'http://video.cnbc.com/gallery/',
+	'http://www.cnbc.com/tv/',
+	'http://www.cnbc.com/id/100003114/device/rss/rss.html',
+	'http://www.cnbc.com/id/100727362/device/rss/rss.html',
+	'http://www.cnbc.com/id/15837362/device/rss/rss.html',
+	'http://www.cnbc.com/id/19832390/device/rss/rss.html',
+	'http://www.cnbc.com/id/19794221/device/rss/rss.html']
+regex = [r'^https?:\/\/[^\/]*cnbc\.com']
+videoregex = []
+liveregex = []

--- a/services/web__economictimes_indiatimes_com.py
+++ b/services/web__economictimes_indiatimes_com.py
@@ -1,0 +1,20 @@
+refresh = 5
+version = 20160403.01
+
+urls = ['http://economictimes.indiatimes.com/',
+	'http://economictimes.indiatimes.com/markets',
+	'http://economictimes.indiatimes.com/news',
+	'http://economictimes.indiatimes.com/industry',
+	'http://economictimes.indiatimes.com/small-biz',
+	'http://economictimes.indiatimes.com/news/politics-nation',
+	'http://economictimes.indiatimes.com/personal-finance',
+	'http://economictimes.indiatimes.com/mutual-funds'',
+	'http://economictimes.indiatimes.com/tech',
+	'http://economictimes.indiatimes.com/jobs',
+	'http://economictimes.indiatimes.com/opinion',
+	'http://economictimes.indiatimes.com/panache',
+	'http://economictimes.indiatimes.com/rssfeedsdefault.cms',
+	'http://economictimes.indiatimes.com/news/rssfeeds/1715249553.cms']
+regex = [r'^https?:\/\/[^\/]*economictimes\.indiatimes\.com']
+videoregex = ['\/video\/']
+liveregex = []

--- a/services/web__forbes_com.py
+++ b/services/web__forbes_com.py
@@ -1,0 +1,13 @@
+refresh = 4
+version = 20160403.01
+
+urls = ['http://www.forbes.com/',
+	'http://www.forbes.com/home_usa/',
+	'http://www.forbes.com/home_europe/',
+	'http://www.forbes.com/home_asia/',
+	'http://www.forbes.com/most-popular/'
+	'http://www.forbes.com/real-time/',
+	'http://www.forbes.com/video/']
+regex = [r'^https?:\/\/[^\/]*forbes\.com']
+videoregex = ['\/video\/']
+liveregex = []

--- a/services/web__huffingtonpost_com.py
+++ b/services/web__huffingtonpost_com.py
@@ -1,0 +1,21 @@
+refresh = 4
+version = 20160403.01
+
+urls = ['http://www.huffingtonpost.com/',
+	'http://www.huffingtonpost.com/politics/',
+	'http://www.huffingtonpost.com/entertainment/',
+	'http://www.huffingtonpost.com/news/whats-working/',
+	'http://www.huffingtonpost.com/healthy-living/',
+	'http://www.huffingtonpost.com/theworldpost/',
+	'http://www.huffingtonpost.com/travel/',
+	'http://www.huffingtonpost.com/business/',
+	'http://www.huffingtonpost.com/tech/',
+	'http://www.huffingtonpost.com/religion/',
+	'http://live.huffingtonpost.com/',
+	'http://feeds.huffingtonpost.com/c/35496/f/677045/index.rss',
+	'http://feeds.huffingtonpost.com/c/35496/f/677497/index.rss',
+	'http://feeds.huffingtonpost.com/c/35496/f/677555/index.rss',
+	'http://www.huffingtonpost.com/syndication/']
+regex = [r'^https?:\/\/[^\/]*huffingtonpost\.com']
+videoregex = []
+liveregex = []

--- a/services/web__indianexpress_com.py
+++ b/services/web__indianexpress_com.py
@@ -1,0 +1,17 @@
+refresh = 5
+version = 20160403.01
+
+urls = ['http://indianexpress.com/',
+	'http://indianexpress.com/india/',
+	'http://indianexpress.com/world/',
+	'http://indianexpress.com/opinion/',
+	'http://indianexpress.com/sports/',
+	'http://indianexpress.com/entertainment/',
+	'http://indianexpress.com/lifestyle/',
+	'http://indianexpress.com/technology/',
+	'http://indianexpress.com/trending/',
+	'http://indianexpress.com/photos/',
+	'http://indianexpress.com/videos/']
+regex = [r'^https?:\/\/[^\/]*indianexpress\.com']
+videoregex = []
+liveregex = []

--- a/services/web__navbharattimes_indiatimes_com.py
+++ b/services/web__navbharattimes_indiatimes_com.py
@@ -1,0 +1,22 @@
+refresh = 6
+version = 20160403.01
+
+urls = ['http://navbharattimes.indiatimes.com/',
+	'http://navbharattimes.indiatimes.com/india/articlelist/1564454.cms',
+	'http://navbharattimes.indiatimes.com/state/articlelist/2279808.cms',
+	'http://navbharattimes.indiatimes.com/world/articlelist/2279801.cms',
+	'http://navbharattimes.indiatimes.com/astro.cms',
+	'http://navbharattimes.indiatimes.com/sports.cms',
+	'http://navbharattimes.indiatimes.com/movie-masti/movies/2279793.cms',
+	'http://navbharattimes.indiatimes.com/jokes.cms',
+	'http://navbharattimes.indiatimes.com/business.cms',
+	'http://navbharattimes.indiatimes.com/business.cms',
+	'http://navbharattimes.indiatimes.com/education.cms',
+	'http://navbharattimes.indiatimes.com/tech.cms',
+	'http://navbharattimes.indiatimes.com/auto/automobile.cms',
+	'http://navbharattimes.indiatimes.com/opinion/articlelist/2279782.cms',
+	'http://navbharattimes.indiatimes.com/other/articlelist/33503918.cms',
+	'http://navbharattimes.indiatimes.com/rssfeeds/33503918.cms']
+regex = [r'^https?:\/\/[^\/]*navbharattimes\.indiatimes\.com']
+videoregex = ['\/video\/']
+liveregex = []

--- a/services/web__nbcnews_com.py
+++ b/services/web__nbcnews_com.py
@@ -1,0 +1,18 @@
+refresh = 5
+version = 20160403.01
+
+urls = ['http://www.nbcnews.com/',
+	'http://www.nbcnews.com/news/us-news',
+	'http://www.nbcnews.com/news/world',
+	'http://www.nbcnews.com/politics',
+	'http://www.nbcnews.com/health',
+	'http://www.nbcnews.com/tech',
+	'http://www.nbcnews.com/science',
+	'http://www.nbcnews.com/pop-culture',
+	'http://www.nbcnews.com/business',
+	'http://www.nbcnews.com/news/investigations',
+	'http://www.nbcnews.com/video',
+	'http://www.nbcnews.com/news/photo']
+regex = [r'^https?:\/\/[^\/]*nbcnews\.com']
+videoregex = ['\/video\/']
+liveregex = []

--- a/services/web__sfgate_com.py
+++ b/services/web__sfgate_com.py
@@ -1,0 +1,28 @@
+refresh = 5
+version = 20160403.01
+
+urls = ['http://www.sfgate.com/',
+	'http://www.sfgate.com/news/',
+	'http://www.sfgate.com/sports/',
+	'http://www.sfgate.com/business/',
+	'http://www.sfgate.com/entertainment/',
+	'http://www.sfgate.com/food/',
+	'http://www.sfgate.com/living/',
+	'http://www.sfgate.com/realestate/',
+	'http://www.sfgate.com/travel/',
+	'http://www.sfgate.com/bayarea/feed/Bay-Area-News-429.php',
+	'http://www.sfgate.com/rss/feed/Business-and-Technology-News-448.php',
+	'http://www.sfgate.com/rss/feed/Daily-Dish-531.php',
+	'http://www.sfgate.com/rss/feed/Entertainment-530.php',
+	'http://www.sfgate.com/rss/feed/Food-Dining-550.php',
+	'http://www.sfgate.com/rss/feed/Jon-Carroll-544.php',
+	'http://www.sfgate.com/rss/feed/Mark-Fiore-563.php',
+	'http://www.sfgate.com/rss/feed/Mark-Morford-Notes-Errata-RSS-Feed-438.php',
+	'http://www.sfgate.com/rss/feed/Page-One-News-593.php',
+	'http://www.sfgate.com/athletics/feed/Oakland-A-s-RSS-Feed-488.php',
+	'http://www.sfgate.com/sports/feed/San-Francisco-Giants-RSS-Feed-428.php',
+	'http://www.sfgate.com/rss/feed/Top-Sports-Stories-RSS-Feed-487.php',
+	'http://www.sfgate.com/rss/feed/Top-News-Stories-595.php']
+regex = [r'^https?:\/\/[^\/]*sfgate\.com']
+videoregex = []
+liveregex = []

--- a/services/web__theatlantic_com.py
+++ b/services/web__theatlantic_com.py
@@ -1,0 +1,14 @@
+refresh = 5
+version = 20160403.01
+
+urls = ['http://www.theatlantic.com/',
+	'http://www.theatlantic.com/world/',
+	'http://www.theatlantic.com/latest/',
+	'http://www.theatlantic.com/most-popular/',
+	'http://www.theatlantic.com/magazine/',
+	'http://www.theatlantic.com/video/',
+	'http://www.theatlantic.com/photo/',
+	'http://feeds.feedburner.com/TheAtlantic']
+regex = [r'^https?:\/\/[^\/]*theatlantic\.com']
+videoregex = []
+liveregex = []

--- a/services/web__time_com.py
+++ b/services/web__time_com.py
@@ -1,0 +1,21 @@
+refresh = 5
+version = 20160403.01
+
+urls = ['http://time.com/',
+	'http://time.com/us/',
+	'http://time.com/politics/',
+	'http://time.com/world/',
+	'http://time.com/business/',
+	'http://time.com/tech/',
+	'http://time.com/health/',
+	'http://time.com/entertainment/',
+	'http://time.com/newsfeed/',
+	'http://time.com/living/',
+	'http://time.com/sports/',
+	'http://time.com/history/',
+	'http://time.com/vault/',
+	'http://time.com/ideas/',
+	'http://time.com/money/']
+regex = [r'^https?:\/\/[^\/]*time\.com']
+videoregex = []
+liveregex = []

--- a/services/web__usatoday_com.py
+++ b/services/web__usatoday_com.py
@@ -1,0 +1,13 @@
+refresh = 5
+version = 20160403.01
+
+urls = ['http://www.usatoday.com/',
+	'http://www.usatoday.com/sports/',
+	'http://www.usatoday.com/life/',
+	'http://www.usatoday.com/money/',
+	'http://www.usatoday.com/tech/',
+	'http://www.usatoday.com/travel/',
+	'http://www.usatoday.com/opinion/']
+regex = [r'^https?:\/\/[^\/]*usatoday\.com']
+videoregex = []
+liveregex = []

--- a/services/web__usnews_com.py
+++ b/services/web__usnews_com.py
@@ -1,0 +1,16 @@
+refresh = 6
+version = 20160403.01
+
+urls = ['http://www.usnews.com/',
+	'http://www.usnews.com/opinion',
+	'http://www.usnews.com/cartoons',
+	'http://www.usnews.com/photos',
+	'http://video.usnews.com/',
+	'http://www.usnews.com/news/the-report',
+	'http://travel.usnews.com/',
+	'http://money.usnews.com/',
+	'http://health.usnews.com/',
+	'http://www.usnews.com/education']
+regex = [r'^https?:\/\/[^\/]*usnews\.com']
+videoregex = ['video\.usnews\.com']
+liveregex = []


### PR DESCRIPTION
List at current time: (http://web.archive.org/web/20160403002351/http://www.alexa.com/topsites/category;0/Top/News and http://web.archive.org/web/20160403002434/http://www.alexa.com/topsites/category;1/Top/News/Weblogs)